### PR TITLE
added get-creds step for users coming from step 5

### DIFF
--- a/01-prerequisites.md
+++ b/01-prerequisites.md
@@ -32,7 +32,7 @@ This document is the starting point for deploying the [AKS Secure Baseline refer
    git clone $GITHUB_REPO
    ```
 
-   > :bulb: The steps shown here and elsewhere in the reference implementation use Bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about#what-is-wsl-2) to run Bash. If you are planning to use VS Code, create a script file to store commands in this tutorial and run them using VS Code's integrated Bash terminal then run `export MSYS_NO_PATHCONV=1` to avoid path mangling.
+   > :bulb: The steps shown here and elsewhere in the reference implementation use Bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about#what-is-wsl-2) to run Bash. If you are planning to use VS Code, create a script file to store commands from this tutorial in it and run using VS Code's integrated Bash terminal then run `export MSYS_NO_PATHCONV=1` to avoid path mangling.
 
 1. Ensure [OpenSSL is installed](https://github.com/openssl/openssl#download) in order to generate self-signed certs used in this implementation.
 1. [JQ](https://stedolan.github.io/jq/download/)

--- a/01-prerequisites.md
+++ b/01-prerequisites.md
@@ -36,6 +36,7 @@ This document is the starting point for deploying the [AKS Secure Baseline refer
 
 1. Ensure [OpenSSL is installed](https://github.com/openssl/openssl#download) in order to generate self-signed certs used in this implementation.
 1. [JQ](https://stedolan.github.io/jq/download/)
+1. Run `export MSYS_NO_PATHCONV=1` to avoid PATH mangling. 
 1. [Helm 3](https://helm.sh)
 
    ```bash

--- a/01-prerequisites.md
+++ b/01-prerequisites.md
@@ -32,11 +32,10 @@ This document is the starting point for deploying the [AKS Secure Baseline refer
    git clone $GITHUB_REPO
    ```
 
-   > :bulb: The steps shown here and elsewhere in the reference implementation use Bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about#what-is-wsl-2) to run Bash.
+   > :bulb: The steps shown here and elsewhere in the reference implementation use Bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about#what-is-wsl-2) to run Bash. If you are planning to use VS Code, create a script file to store commands in this tutorial and run them using VS Code's integrated Bash terminal then run `export MSYS_NO_PATHCONV=1` to avoid path mangling.
 
 1. Ensure [OpenSSL is installed](https://github.com/openssl/openssl#download) in order to generate self-signed certs used in this implementation.
 1. [JQ](https://stedolan.github.io/jq/download/)
-1. Run `export MSYS_NO_PATHCONV=1` to avoid PATH mangling. 
 1. [Helm 3](https://helm.sh)
 
    ```bash

--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -40,9 +40,13 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrappi
 
 1. Confirm policies are applied to the AKS cluster
 
-   ```bash
+    ```bash
+    export AKS_CLUSTER_NAME=$(az deployment group show --resource-group rg-shipping-dronedelivery -n cluster-stamp --query properties.outputs.aksClusterName.value -o tsv)
+
+    az aks get-credentials -g rg-shipping-dronedelivery -n $AKS_CLUSTER_NAME
+
    kubectl get constrainttemplate
-   ```
+    ```
 
    The output should look similar to this:
 

--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -40,7 +40,7 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrappi
 
 1. Confirm policies are applied to the AKS cluster
 
-    ```bash
+   ```bash
     export AKS_CLUSTER_NAME=$(az deployment group show --resource-group rg-shipping-dronedelivery -n cluster-stamp --query properties.outputs.aksClusterName.value -o tsv)
 
     az aks get-credentials -g rg-shipping-dronedelivery -n $AKS_CLUSTER_NAME

--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -46,7 +46,7 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrappi
     az aks get-credentials -g rg-shipping-dronedelivery -n $AKS_CLUSTER_NAME
 
    kubectl get constrainttemplate
-    ```
+   ```
 
    The output should look similar to this:
 


### PR DESCRIPTION
users coming from step 5 (option 2 - gitops) should set the AKS context first before running `kubectl get constrainttemplate`